### PR TITLE
Fixed double escape of strings

### DIFF
--- a/Convertor.class.php
+++ b/Convertor.class.php
@@ -221,7 +221,7 @@
                         if (( $v == '' ) && ( isset( $this->tableFields['null'] ) ) && ( $this->tableFields['null'][$n] === true )) {
                             $v = 'NULL';
 						} else {
-							$v = "'".pg_escape_string($v)."'";
+							$v = "'".$v."'";
 						}
 					}
 					unset($v);


### PR DESCRIPTION
Single quotes in XML end up as 4 quotes in the SQL instead of 2. This PR fixes it.