### PR TITLE
"VARCHAR" convert to "text"

### DIFF
--- a/Convertor.class.php
+++ b/Convertor.class.php
@@ -283,7 +283,10 @@
                 } elseif (substr( $attrs['Type'], 0, 4 ) == "blob") {
                     $fieldStr .= "bytea ";
                 } elseif (substr( $attrs['Type'], 0, 7 ) == "varchar") {
-                    $fieldStr .= "text ";
+                    $varcharLen = array();
+                    preg_match('/\(([0-9]+)\)/', $attrs['Type'], $varcharLen);
+                    $varcharLen = isset($varcharLen[1]) ? $varcharLen[1] : "0";
+                    $fieldStr .= "varchar({$varcharLen}) ";
                 } elseif (( $attrs['Type'] == "datetime" ) || ( $attrs['Type'] == "timestamp" )) {
                     $fieldStr .= "{$this->timestampType} ";
                 } elseif (( $attrs['Type'] == "mediumtext" ) || ( $attrs['Type'] == "tinytext" ) || ( $attrs['Type'] == "longtext" )

--- a/Convertor.class.php
+++ b/Convertor.class.php
@@ -284,9 +284,12 @@
                     $fieldStr .= "bytea ";
                 } elseif (substr( $attrs['Type'], 0, 7 ) == "varchar") {
                     $varcharLen = array();
-                    preg_match('/\(([0-9]+)\)/', $attrs['Type'], $varcharLen);
-                    $varcharLen = isset($varcharLen[1]) ? $varcharLen[1] : "0";
-                    $fieldStr .= "varchar({$varcharLen}) ";
+                    if (preg_match('/\(([0-9]+)\)/', $attrs['Type'], $varcharLen) === 1) {
+                        $varcharLen = isset($varcharLen[1]) ? $varcharLen[1] : "0";
+                        $fieldStr .= "varchar({$varcharLen}) ";
+                    } else {
+                        $fieldStr .= "text ";
+                    }
                 } elseif (( $attrs['Type'] == "datetime" ) || ( $attrs['Type'] == "timestamp" )) {
                     $fieldStr .= "{$this->timestampType} ";
                 } elseif (( $attrs['Type'] == "mediumtext" ) || ( $attrs['Type'] == "tinytext" ) || ( $attrs['Type'] == "longtext" )


### PR DESCRIPTION
MySQL table type is set "varchar(20)", but convert to PostgreSQL field type is "text". This request can convert to "varchar". PostgreSQL field type "varchar" or "text"  type is ambiguous. but some Web framework see field type (ex: CakePHP. PostgreSQL field type is "varchar", set input type "text", but PostgreSQL field type is "text", set "textarea").